### PR TITLE
Update run.sh

### DIFF
--- a/ModTek/DoorStop/run.sh
+++ b/ModTek/DoorStop/run.sh
@@ -63,7 +63,9 @@ case ${os_type} in
     #Work around used as it is a bug that is patched out in newer versions of mono.
     export TERM=xterm
 
-    export LD_PRELOAD="${BASEDIR}/libdoorstop.so:${LD_PRELOAD:-}"
+    #LD_PRELOAD can't handle whitespaces as good as LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH="${BASEDIR}"
+    export LD_PRELOAD="libdoorstop.so:${LD_PRELOAD:-}"
     LD_PRELOAD="${LD_PRELOAD%:}"
   ;;
   Darwin*)


### PR DESCRIPTION
fixes bta light not being able to launch on steam deck\linux.

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
